### PR TITLE
README Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@ THIS IS THE OWASP TESTING GUIDE PROJECT ROADMAP FOR V5.
 You can download the stable version v4 here:
 http://www.owasp.org/index.php/OWASP_Testing_Project
 
-WHAT
+## WHAT
 The OWASP Testing Guide v4 includes a “best practice” penetration testing framework which users can implement in their own organisations. The Testing Guide v4 also includes a “low level” penetration testing guide that describes techniques for testing the most common web application and web service security issues. Today the Testing Guide is the standard to perform Web Application Penetration Testing, and many companies around the world have adopted it. It is vital to maintain an updated project that represents the state of the art for WebAppSec.
 
 The aim of the Working Session is to discuss and define the scope and content of OWASP Testing Guide v5.
 
-OUTCOMES
-All sections in v4 reviewed
-Project aligned with the ASVS and OWASP Top 10 vulnerabilities
-A more readable guide created that eliminates sections that are not useful
-New testing techniques inserted
-Some sections rationalised as Session Management Testing
-New section created: Client side security and Firefox extensions testing
-Project v5 Deadlines:
-21st March 2017: Setup the team of authors
-22th March 2017: Start a brainstorming for the new index starting from “Release Description”
-15th April 2017: Create the new index and confirm new team
-15th May 2017: Start writing articles first phase
-12-16 June 2017: OWASP Summit TGv5 review and brainstorming
-17th June 2017: Start writing articles II phase
-1st October 2017: Start the second review phase
-15th November 2017: Create the RC1
-15th January 2017: Release version 5
+## OUTCOMES
+* All sections in v4 reviewed
+* Project aligned with the ASVS and OWASP Top 10 vulnerabilities
+* A more readable guide created that eliminates sections that are not useful
+* New testing techniques inserted
+* Some sections rationalised as Session Management Testing
+* New section created: Client side security and Firefox extensions testing
+* Project v5 Deadlines:
+* 21st March 2017: Setup the team of authors
+* 22th March 2017: Start a brainstorming for the new index starting from “Release Description”
+* 15th April 2017: Create the new index and confirm new team
+* 15th May 2017: Start writing articles first phase
+* 12-16 June 2017: OWASP Summit TGv5 review and brainstorming
+* 17th June 2017: Start writing articles II phase
+* 1st October 2017: Start the second review phase
+* 15th November 2017: Create the RC1
+* 15th January 2017: Release version 5


### PR DESCRIPTION
Just to make things more readable:
- Set level 2 headings.
- Bulleted the list of "outcomes".

Obviously the dates on the "outcomes" are no longer valid, however, I haven't seen any updates on the mailing list or news from the 2018 Summit. So for the time being I left them as-is.