### PR TITLE
Add Label to fix-request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix-request.md
+++ b/.github/ISSUE_TEMPLATE/fix-request.md
@@ -2,7 +2,7 @@
 name: Fix Request
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: QA/Edit
 assignees: ''
 
 ---


### PR DESCRIPTION
- [x] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.
  - As [discussed](https://github.com/OWASP/OWASP-Testing-Guide-v5/pull/54#discussion_r280816356).

**What did this PR accomplish?**

- Add the `QA/Edit` label as default for the fix-request.md issue template.

Fixes OWASP/OWASP-Testing-Guide-v5#51

_Edit: Reverted silly git/Eclipse EOL change :disappointed:_ 