### PR TITLE
Section 1 Changes for v5

### DIFF
--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -2,7 +2,7 @@
 
 Placeholder-TBC
 
-## Version 4.0
+## Version 5.0
 
 Placeholder-TBC
 

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -16,10 +16,10 @@ This document is released under the [Creative Commons 4.0 License](https://creat
 
 
 - Tal Argoni
-- [Manh Pham Tien](https://www.linkedin.com/in/manhnho/)
+- Manh Pham Tien
 - Rubal Jain
 - Mark Clayton
-- [Janos Zold](https://www.linkedin.com/in/janoszold/)
+- Janos Zold
 
 ## v5 Reviewers/Editors
 

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -16,7 +16,7 @@ This document is released under the [Creative Commons 4.0 License](https://creat
 
 ```
   - Tal Argoni
-  - Manh Pham Tien
+  - [Manh Pham Tien](https://www.linkedin.com/in/manhnho/)
   - Rubal Jain
   - Mark Clayton
 ```

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -14,19 +14,16 @@ This document is released under the [Creative Commons 4.0 License](https://creat
 
 ## v5 Authors
 
-```
-  - Tal Argoni
-  - [Manh Pham Tien](https://www.linkedin.com/in/manhnho/)
-  - Rubal Jain
-  - Mark Clayton
-```
+
+- Tal Argoni
+- [Manh Pham Tien](https://www.linkedin.com/in/manhnho/)
+- Rubal Jain
+- Mark Clayton
 
 ## v5 Reviewers/Editors
 
-```
-  - Rick Mitchell
-  - Elie Saad
-```
+- Rick Mitchell
+- Elie Saad
 
 ## Trademarks
 

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -1,152 +1,41 @@
-Welcome to the OWASP Testing Guide 4.0
---------------------------------------
+## Welcome to the OWASP Testing Guide 5.0
 
-“Open and collaborative knowledge: that is the OWASP way.” <br>
-With V4 we realized a new guide that will be the standard de-facto guide to perform Web Application Penetration Testing. -- [Matteo Meucci](https://www.owasp.org/index.php/Matteo_Meucci)
+Placeholder-TBC
 
-OWASP thanks the many authors, reviewers, and editors for their hard work in bringing this guide to where it is today. If you have any comments or suggestions on the Testing Guide, please e-mail the Testing Guide mail list: [http://lists.owasp.org/mailman/listinfo/owasp-testing](http://lists.owasp.org/mailman/listinfo/owasp-testing)
+## Version 4.0
 
-Or drop an e-mail to the project leaders: [Andrew Muller](mailto:andrew.muller@owasp.org) and [Matteo Meucci](mailto:matteo.meucci@owasp.org)
+Placeholder-TBC
 
-Version 4.0
------------
+## Copyright and Licensee
 
-The OWASP Testing Guide version 4 improves on version 3 in three ways:
+Copyright (c) 2019 The OWASP Foundation. <br>
 
-1. This version of the Testing Guide integrates with the two other flagship OWASP documentation products: the Developers Guide and the Code Review Guide. To achieve this we aligned the testing categories and test numbering with those in other OWASP products. The aim of the Testing and Code Review Guides is to evaluate the security controls described by the Developers Guide.
+This document is released under the [Creative Commons 2.5 License](https://creativecommons.org/licenses/by-sa/4.0/). Please read and understand the license and copyright conditions.
 
-2. All chapters have been improved and test cases expanded to 87 (64 test cases in v3) including the introduction of four new chapters and controls:
-	- Identity Management Testing
-	- Error Handling
-	- Cryptography
-	- Client Side Testing
-  
-3. This version of the Testing Guide encourages the community not to simply accept the test cases outlined in this guide. We encourage security testers to integrate with other software testers and devise test cases specific to the target application. As we find test cases that have wider applicability we encourage the security testing community to share them and contribute them to the Testing Guide. This will continue to build the application security body of knowledge and allow the development of the Testing Guide to be an iterative rather than monolithic process..
+## v5 Authors
 
-Copyright and Licensee
----------------------
+```
+  - Tal Argoni
+  - Manh Pham Tien
+  - Rubal Jain
+  - Mark Clayton
+```
 
-Copyright (c) 2014 The OWASP Foundation. <br>
+## v5 Reviewers/Editors
 
-This document is released under the [Creative Commons 2.5 License](http://creativecommons.org/licenses/by-sa/2.5/). Please read and understand the license and copyright conditions.
+```
+  - Rick Mitchell
+  - Elie Saad
+```
 
-Revision History
-----------------
+## Trademarks
 
-The Testing Guide v4 will be released in 2014. The Testing guide originated in 2003 with Dan Cuthbert as one of the original editors. It was handed over to Eoin Keary in 2005 and transformed into a wiki. Matteo Meucci has taken on the Testing guide and is now the lead of the OWASP Testing Guide Project. From 2012 Andrew Muller co-leadership the project with Matteo Meucci.
-
-September, 2014 :   “OWASP Testing Guide”, Version 4.0 <br>
-September, 2008 :   “OWASP Testing Guide”, Version 3.0 <br>
-December, 2006 :   “OWASP Testing Guide”, Version 2.0 <br>
-July, 2004 :   “OWASP Web Application Penetration Checklist”, Version 1.1 <br>
-December, 2004 :   “The OWASP Testing Guide”, Version 1.0 <br>
-
-Editors
--------
-
-**Andrew Muller**: OWASP Testing Guide Lead since 2013. <br>
-**Matteo Meucci**: OWASP Testing Guide Lead since 2007. <br>
-**Eoin Keary**: OWASP Testing Guide 2005-2007 Lead. <br>
-**Daniel Cuthbert**: OWASP Testing Guide 2003-2005 Lead.
-
-v4 Authors
-----------
-
-  ----------------------------
-<pre>
-  -   Matteo Meucci            -   Cecil Su            -   Brad Causey            -   Davide Danelon
-  -   Pavol Luptak             -   Aung KhAnt          -   Vicente Aguilera       -   Alexander Antukh
-  -   Marco Morana             -   Norbert Szetei      -   Ismael Gonçalves       -   Thomas Kalamaris
-  -   Giorgio Fedon            -   Michael Boman       -   David Fern             -   Alexander Vavousis
-  -   Stefano Di Paola         -   Wagner Elias        -   Tom Eston              -   Clerkendweller
-  -   Gianrico Ingrosso        -   Kevin Horvat        -   Kevin Horvath          -   Christian Heinrich
-  -   Giuseppe Bonfà           -   Tom Brennan         -   Rick Mitchell          -   Babu Arokiadas
-  -   Andrew Muller            -   Juan Galiana Lara   -   Eduardo Castellanos    -   Rob Barnes
-  -   Robert Winkel            -   Sumit Siddharth     -   Simone Onofri          -   Ben Walther
-  -   Roberto Suggi Liverani   -   Mike Hryekewicz     -   Harword Sheen          
-  -   Robert Smith             -   Simon Bennetts      -   Amro AlOlaqi           
-  -   Tripurari Rai            -   Ray Schippers       -   Suhas Desai            
-  -   Thomas Ryan              -   Raul Siles          -   Tony Hsu Hsiang Chih   
-  -   Tim Bertels              -   Jayanta Karmakar    -   Ryan Dewhurst   
-  -   Zaki Akhmad
-</pre>
-  ----------------------------
-
-v4 Reviewers
-------------
-
-  -------------------------
-<pre>
-  -   Davide Danelon
-  -   Andrea Rosignoli
-  -   Irene Abezgauz
-  -   Lode Vanstechelman
-  -   Sebastien Gioria
-  -   Yiannis Pavlosoglou
-  -   Aditya Balapure
-</pre>
-  -------------------------
-
-v3 Authors
-----------
-
-  ----------------------
-<pre>
-  -   Anurag Agarwwal    -   Giorgio Fedon        -   Gianrico Ingrosso        -   Ferruh Mavituna   -   Antonio Parata          -   Andrew Van der Stock
-  -   Daniele Bellucci   -   Adam Goodman         -   Roberto Suggi Liverani   -   Marco Mella       -   Cecil Su                
-  -   Ariel Coronel      -   Christian Heinrich   -   Kuza55                   -   Matteo Meucci     -   Harish Skanda Sureddy   
-  -   Stefano Di Paola   -   Kevin Horvath        -   Pavol Luptak             -   Marco Morana      -   Mark Roxberry           
-</pre>
-  ---------------------- 
-
-v3 Reviewers
-------------
-
-  ------------------
-<pre>
-  -   Marco Cova     -   Matteo Meucci   -   Rick Mitchell
-  -   Kevin Fuller   -   Nam Nguyen      
-</pre>
-  ------------------ 
-
-v2 Authors
-----------
-
-  ----------------------------
-<pre>
-  -   Vicente Aguilera         -   David Endler                -   Matteo Meucci         -   Anush Shetty
-  -   Mauro Bregolin           -   Giorgio Fedon               -   Marco Morana          -   Larry Shields
-  -   Tom Brennan              -   Javier Fernández-Sanguino   -   Laura Nunez           -   Dafydd Studdard
-  -   Gary Burns               -   Glyn Geoghegan              -   Gunter Ollmann        -   Andrew van der Stock
-  -   Luca Carettoni           -   Stan Guzik                  -   Antonio Parata        -   Ariel Waissbein
-  -   Dan Cornell              -   Madhura Halasgikar          -   Yiannis Pavlosoglou   -   Jeff Williams
-  -   Mark Curphey             -   Eoin Keary                  -   Carlo Pelliccioni     -   Tushar Vartak
-  -   Daniel Cuthbert          -   David Litchfield            -   Harinath Pudipeddi    
-  -   Sebastien Deleersnyder   -   Andrea Lombardini           -   Alberto Revelli       
-  -   Stephen DeVries          -   Ralph M. Los                -   Mark Roxberry         
-  -   Stefano Di Paola         -   Claudio Merloni             -   Tom Ryan              
-</pre>
-  ---------------------------- 
-
-v2 Reviewers
-------------
-
-  ---------------------- 
-<pre>
-  -   Vicente Aguilera   -   Mauro Bregolin   -   Daniel Cuthbert   -   Stefano Di Paola    -   Simona Forti      -   Eoin Keary   -   Katie McDowell   -   Matteo Meucci     -   Antonio Parata    -   Mark Roxberry
-  -   Marco Belotti      -   Marco Cova       -   Paul Davies       -   Matteo G.P. Flora   -   Darrell Groundy   -   James Kist   -   Marco Mella      -   Syed Mohamed A.   -   Alberto Revelli   -   Dave Wichers
-</pre>
-  ---------------------- 
-
-Trademarks
-----------
-
--   Java, Java Web Server, and JSP are registered trademarks of Sun Microsystems, Inc.
--   Merriam-Webster is a trademark of Merriam-Webster, Inc.
--   Microsoft is a registered trademark of Microsoft Corporation.
--   Octave is a service mark of Carnegie Mellon University.
--   VeriSign and Thawte are registered trademarks of VeriSign, Inc.
--   Visa is a registered trademark of VISA USA.
--   OWASP is a registered trademark of the OWASP Foundation
+- Java, Java Web Server, and JSP are registered trademarks of Sun Microsystems, Inc.
+- Merriam-Webster is a trademark of Merriam-Webster, Inc.
+- Microsoft is a registered trademark of Microsoft Corporation.
+- Octave is a service mark of Carnegie Mellon University.
+- VeriSign and Thawte are registered trademarks of VeriSign, Inc.
+- Visa is a registered trademark of VISA USA.
+- OWASP is a registered trademark of the OWASP Foundation
 
 All other products and company names may be trademarks of their respective owners. Use of a term in this document should not be regarded as affecting the validity of any trademark or service mark.

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -10,7 +10,7 @@ Placeholder-TBC
 
 Copyright (c) 2019 The OWASP Foundation. <br>
 
-This document is released under the [Creative Commons 2.5 License](https://creativecommons.org/licenses/by-sa/4.0/). Please read and understand the license and copyright conditions.
+This document is released under the [Creative Commons 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/). Please read and understand the license and copyright conditions.
 
 ## v5 Authors
 

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -19,6 +19,7 @@ This document is released under the [Creative Commons 4.0 License](https://creat
 - [Manh Pham Tien](https://www.linkedin.com/in/manhnho/)
 - Rubal Jain
 - Mark Clayton
+- [Janos Zold](https://www.linkedin.com/in/janoszold/)
 
 ## v5 Reviewers/Editors
 

--- a/document/1 Frontispiece/1 Frontispiece.md
+++ b/document/1 Frontispiece/1 Frontispiece.md
@@ -8,7 +8,7 @@ Placeholder-TBC
 
 ## Copyright and Licensee
 
-Copyright (c) 2019 The OWASP Foundation. <br>
+Copyright (c) 2019 The OWASP Foundation.
 
 This document is released under the [Creative Commons 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/). Please read and understand the license and copyright conditions.
 

--- a/document/Appx.E Misc/AppxE History.md
+++ b/document/Appx.E Misc/AppxE History.md
@@ -2,18 +2,18 @@
 
 The Testing Guide v4 will be released in 2014. The Testing guide originated in 2003 with Dan Cuthbert as one of the original editors. It was handed over to Eoin Keary in 2005 and transformed into a wiki. Matteo Meucci has taken on the Testing guide and is now the lead of the OWASP Testing Guide Project. From 2012 Andrew Muller co-leadership the project with Matteo Meucci.
 
-September, 2014 :   “OWASP Testing Guide”, Version 4.0 <br>
-September, 2008 :   “OWASP Testing Guide”, Version 3.0 <br>
-December, 2006 :   “OWASP Testing Guide”, Version 2.0 <br>
-July, 2004 :   “OWASP Web Application Penetration Checklist”, Version 1.1 <br>
-December, 2004 :   “The OWASP Testing Guide”, Version 1.0 <br>
+- September, 2014 :   “OWASP Testing Guide”, Version 4.0
+- September, 2008 :   “OWASP Testing Guide”, Version 3.0
+- December, 2006 :   “OWASP Testing Guide”, Version 2.0
+- July, 2004 :   “OWASP Web Application Penetration Checklist”, Version 1.1
+- December, 2004 :   “The OWASP Testing Guide”, Version 1.0
 
 ### Leaders
 
-Andrew Muller: OWASP Testing Guide Lead since 2013. <br>
-Matteo Meucci: OWASP Testing Guide Lead since 2007. <br>
-Eoin Keary: OWASP Testing Guide 2005-2007 Lead. <br>
-Daniel Cuthbert: OWASP Testing Guide 2003-2005 Lead.
+- Andrew Muller: OWASP Testing Guide Lead since 2013.
+- Matteo Meucci: OWASP Testing Guide Lead since 2007.
+- Eoin Keary: OWASP Testing Guide 2005-2007 Lead.
+- Daniel Cuthbert: OWASP Testing Guide 2003-2005 Lead.
 
 ### v4 Authors
 

--- a/document/Appx.E Misc/AppxE History.md
+++ b/document/Appx.E Misc/AppxE History.md
@@ -1,0 +1,87 @@
+## Revision History
+
+The Testing Guide v4 will be released in 2014. The Testing guide originated in 2003 with Dan Cuthbert as one of the original editors. It was handed over to Eoin Keary in 2005 and transformed into a wiki. Matteo Meucci has taken on the Testing guide and is now the lead of the OWASP Testing Guide Project. From 2012 Andrew Muller co-leadership the project with Matteo Meucci.
+
+September, 2014 :   “OWASP Testing Guide”, Version 4.0 <br>
+September, 2008 :   “OWASP Testing Guide”, Version 3.0 <br>
+December, 2006 :   “OWASP Testing Guide”, Version 2.0 <br>
+July, 2004 :   “OWASP Web Application Penetration Checklist”, Version 1.1 <br>
+December, 2004 :   “The OWASP Testing Guide”, Version 1.0 <br>
+
+### Leaders
+
+Andrew Muller: OWASP Testing Guide Lead since 2013. <br>
+Matteo Meucci: OWASP Testing Guide Lead since 2007. <br>
+Eoin Keary: OWASP Testing Guide 2005-2007 Lead. <br>
+Daniel Cuthbert: OWASP Testing Guide 2003-2005 Lead.
+
+### v4 Authors
+
+```
+  -   Matteo Meucci            -   Cecil Su            -   Brad Causey            -   Davide Danelon
+  -   Pavol Luptak             -   Aung KhAnt          -   Vicente Aguilera       -   Alexander Antukh
+  -   Marco Morana             -   Norbert Szetei      -   Ismael Gonçalves       -   Thomas Kalamaris
+  -   Giorgio Fedon            -   Michael Boman       -   David Fern             -   Alexander Vavousis
+  -   Stefano Di Paola         -   Wagner Elias        -   Tom Eston              -   Clerkendweller
+  -   Gianrico Ingrosso        -   Kevin Horvat        -   Kevin Horvath          -   Christian Heinrich
+  -   Giuseppe Bonfà           -   Tom Brennan         -   Rick Mitchell          -   Babu Arokiadas
+  -   Andrew Muller            -   Juan Galiana Lara   -   Eduardo Castellanos    -   Rob Barnes
+  -   Robert Winkel            -   Sumit Siddharth     -   Simone Onofri          -   Ben Walther
+  -   Roberto Suggi Liverani   -   Mike Hryekewicz     -   Harword Sheen          
+  -   Robert Smith             -   Simon Bennetts      -   Amro AlOlaqi           
+  -   Tripurari Rai            -   Ray Schippers       -   Suhas Desai            
+  -   Thomas Ryan              -   Raul Siles          -   Tony Hsu Hsiang Chih   
+  -   Tim Bertels              -   Jayanta Karmakar    -   Ryan Dewhurst   
+  -   Zaki Akhmad
+```
+
+### v4 Reviewers
+
+```
+  -   Davide Danelon
+  -   Andrea Rosignoli
+  -   Irene Abezgauz
+  -   Lode Vanstechelman
+  -   Sebastien Gioria
+  -   Yiannis Pavlosoglou
+  -   Aditya Balapure
+```
+
+### v3 Authors
+
+```
+  -   Anurag Agarwwal    -   Giorgio Fedon        -   Gianrico Ingrosso        -   Ferruh Mavituna   -   Antonio Parata          -   Andrew Van der Stock
+  -   Daniele Bellucci   -   Adam Goodman         -   Roberto Suggi Liverani   -   Marco Mella       -   Cecil Su                
+  -   Ariel Coronel      -   Christian Heinrich   -   Kuza55                   -   Matteo Meucci     -   Harish Skanda Sureddy   
+  -   Stefano Di Paola   -   Kevin Horvath        -   Pavol Luptak             -   Marco Morana      -   Mark Roxberry           
+```
+
+### v3 Reviewers
+
+```
+  -   Marco Cova     -   Matteo Meucci   -   Rick Mitchell
+  -   Kevin Fuller   -   Nam Nguyen      
+```
+
+### v2 Authors
+
+```
+  -   Vicente Aguilera         -   David Endler                -   Matteo Meucci         -   Anush Shetty
+  -   Mauro Bregolin           -   Giorgio Fedon               -   Marco Morana          -   Larry Shields
+  -   Tom Brennan              -   Javier Fernández-Sanguino   -   Laura Nunez           -   Dafydd Studdard
+  -   Gary Burns               -   Glyn Geoghegan              -   Gunter Ollmann        -   Andrew van der Stock
+  -   Luca Carettoni           -   Stan Guzik                  -   Antonio Parata        -   Ariel Waissbein
+  -   Dan Cornell              -   Madhura Halasgikar          -   Yiannis Pavlosoglou   -   Jeff Williams
+  -   Mark Curphey             -   Eoin Keary                  -   Carlo Pelliccioni     -   Tushar Vartak
+  -   Daniel Cuthbert          -   David Litchfield            -   Harinath Pudipeddi    
+  -   Sebastien Deleersnyder   -   Andrea Lombardini           -   Alberto Revelli       
+  -   Stephen DeVries          -   Ralph M. Los                -   Mark Roxberry         
+  -   Stefano Di Paola         -   Claudio Merloni             -   Tom Ryan              
+```
+
+### v2 Reviewers
+
+```
+  -   Vicente Aguilera   -   Mauro Bregolin   -   Daniel Cuthbert   -   Stefano Di Paola    -   Simona Forti      -   Eoin Keary   -   Katie McDowell   -   Matteo Meucci     -   Antonio Parata    -   Mark Roxberry
+  -   Marco Belotti      -   Marco Cova       -   Paul Davies       -   Matteo G.P. Flora   -   Darrell Groundy   -   James Kist   -   Marco Mella      -   Syed Mohamed A.   -   Alberto Revelli   -   Dave Wichers
+```


### PR DESCRIPTION
- [ ] This PR handles the issue and requires no additional PRs.
- [x] You have validated the need for this change.
  - Per discussion here &gt; https://groups.google.com/a/owasp.org/forum/#!topic/testing-guide-project/XFsns2dbPj8

**What did this PR accomplish?**

* Moved contribution history to Appendix E.
* Added `Placeholder-TBC` to v5 lead-in sections.
* Set copyright to 2019 (can be updated further later if required).
* Started v5 Authors and Reviewers/Editors sections. (After this is merged we can ask/remind people to update this section).
* Implemented proper markdown headings and removed hyphen lines.
* Removed `<pre>` and `<br>` HTML tags.

Edit: At some point the contributors list(s) might have to change to tables, but we'll start like this for now and see how it goes.