### PR TITLE
Feature/outdated links 4.2.6 issue 67

### DIFF
--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -10,7 +10,7 @@ Understand how requests are formed and typical responses from the application
 
 Before any testing begins, the tester should always get a good understanding of the application and how the user and browser communicates with it. As the tester walks through the application, they should pay special attention to all HTTP requests (GET and POST Methods, also known as Verbs), as well as every parameter and form field that is passed to the application. In addition, they should pay attention to when GET requests are used and when POST requests are used to pass parameters to the application. It is very common that GET requests are used, but when sensitive information is passed, it is often done within the body of a POST request.
 
-Note that to see the parameters sent in a POST request, the tester will need to use a tool such as an intercepting proxy (for example, OWASP: [ Zed Attack Proxy (ZAP)](OWASP_Zed_Attack_Proxy_Project "wikilink")) or a browser plug-in. Within the POST request, the tester should also make special note of any hidden form fields that are being passed to the application, as these usually contain sensitive information, such as state information, quantity of items, the price of items, that the developer never intended for you to see or change.
+Note that to see the parameters sent in a POST request, the tester will need to use a tool such as an intercepting proxy or a browser plug-in (See [tools](#tools)). Within the POST request, the tester should also make special note of any hidden form fields that are being passed to the application, as these usually contain sensitive information, such as state information, quantity of items, the price of items, that the developer never intended for you to see or change.
 
 In the author's experience, it has been very useful to use an intercepting proxy and a spreadsheet for this stage of the testing. The proxy will keep track of every request and response between the tester and the application as they walk through it. Additionally, at this point, testers usually trap every request and response so that they can see exactly every header, parameter, etc. that is being passed to the application and what is being returned. This can be quite tedious at times, especially on large interactive sites (think of a banking application). However, experience will show what to look for and this phase can be significantly reduced.
 
@@ -72,7 +72,7 @@ In this example the tester would note all the parameters as they have before but
 
 Testing for application entry points via a Gray Box methodology would consist of everything already identified above with one addition. In cases where there are external sources from which the application receives data and processes it (such as SNMP traps, syslog messages, SMTP, or SOAP messages from other servers) a meeting with the application developers could identify any functions that would accept or expect user input and how they are formatted. For example, the developer could help in understanding how to formulate a correct SOAP request that the application would accept and where the web service resides (if the web service or any other function hasn't already been identified during the black box testing).
 
-## Tools
+## <a name="tools"></a>Tools
 
 - [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org/)
 - [Burp Suite](https://www.portswigger.net/burp/)

--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -74,17 +74,10 @@ Testing for application entry points via a Gray Box methodology would consist of
 
 ## Tools
 
--   OWASP: [ Zed Attack Proxy (ZAP)](OWASP_Zed_Attack_Proxy_Project "wikilink")
--   OWASP: [ WebScarab](OWASP_WebScarab_Project "wikilink")
--   [Burp Suite](http://www.portswigger.net/burp/)
--   [CAT](http://www.contextis.com/research/tools/cat/)
--   [TamperIE for Internet Explorer](http://www.bayden.com/TamperIE/)
--   [Tamper Data for Firefox](https://addons.mozilla.org/en-US/firefox/addon/966)
+- [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org/)
+- [Burp Suite](https://www.portswigger.net/burp/)
+- [Fiddler](https://www.telerik.com/fiddler)
 
 ## References
 
-**Whitepapers**
-
--   RFC 2616 – Hypertext Transfer Protocol – HTTP 1.1 -
-
-<http://tools.ietf.org/html/rfc2616>
+- [RFC 2616 – Hypertext Transfer Protocol – HTTP 1.1](https://tools.ietf.org/html/rfc2616)

--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -1,15 +1,12 @@
-Summary
--------
+## Summary
 
 Enumerating the application and its attack surface is a key precursor before any thorough testing can be undertaken, as it allows the tester to identify likely areas of weakness. This section aims to help identify and map out areas within the application that should be investigated once enumeration and mapping have been completed.
 
-Test Objectives
----------------
+## Test Objectives
 
 Understand how requests are formed and typical responses from the application
 
-How to Test
------------
+## How to Test
 
 Before any testing begins, the tester should always get a good understanding of the application and how the user and browser communicates with it. As the tester walks through the application, they should pay special attention to all HTTP requests (GET and POST Methods, also known as Verbs), as well as every parameter and form field that is passed to the application. In addition, they should pay attention to when GET requests are used and when POST requests are used to pass parameters to the application. It is very common that GET requests are used, but when sensitive information is passed, it is often done within the body of a POST request.
 
@@ -39,8 +36,8 @@ Below are some points of interests for all requests and responses. Within the re
 
 ### Black Box Testing
 
-**Testing for application entry points:**\
-The following are two examples on how to check for application entry points.\
+**Testing for application entry points:**
+The following are two examples on how to check for application entry points.
 
 #### EXAMPLE 1
 
@@ -75,25 +72,18 @@ In this example the tester would note all the parameters as they have before but
 
 Testing for application entry points via a Gray Box methodology would consist of everything already identified above with one addition. In cases where there are external sources from which the application receives data and processes it (such as SNMP traps, syslog messages, SMTP, or SOAP messages from other servers) a meeting with the application developers could identify any functions that would accept or expect user input and how they are formatted. For example, the developer could help in understanding how to formulate a correct SOAP request that the application would accept and where the web service resides (if the web service or any other function hasn't already been identified during the black box testing).
 
-Tools
------
-
-**Intercepting Proxy:**\
+## Tools
 
 -   OWASP: [ Zed Attack Proxy (ZAP)](OWASP_Zed_Attack_Proxy_Project "wikilink")
 -   OWASP: [ WebScarab](OWASP_WebScarab_Project "wikilink")
 -   [Burp Suite](http://www.portswigger.net/burp/)
 -   [CAT](http://www.contextis.com/research/tools/cat/)
-
-**Browser Plug-in:**\
-
 -   [TamperIE for Internet Explorer](http://www.bayden.com/TamperIE/)
 -   [Tamper Data for Firefox](https://addons.mozilla.org/en-US/firefox/addon/966)
 
-References
-----------
+## References
 
-**Whitepapers**\
+**Whitepapers**
 
 -   RFC 2616 – Hypertext Transfer Protocol – HTTP 1.1 -
 

--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -10,7 +10,7 @@ Understand how requests are formed and typical responses from the application
 
 Before any testing begins, the tester should always get a good understanding of the application and how the user and browser communicates with it. As the tester walks through the application, they should pay special attention to all HTTP requests (GET and POST Methods, also known as Verbs), as well as every parameter and form field that is passed to the application. In addition, they should pay attention to when GET requests are used and when POST requests are used to pass parameters to the application. It is very common that GET requests are used, but when sensitive information is passed, it is often done within the body of a POST request.
 
-Note that to see the parameters sent in a POST request, the tester will need to use a tool such as an intercepting proxy or a browser plug-in (See [tools](#tools)). Within the POST request, the tester should also make special note of any hidden form fields that are being passed to the application, as these usually contain sensitive information, such as state information, quantity of items, the price of items, that the developer never intended for you to see or change.
+Note that to see the parameters sent in a POST request, the tester will need to use a tool such as an intercepting proxy (See [tools](#tools)). Within the POST request, the tester should also make special note of any hidden form fields that are being passed to the application, as these usually contain sensitive information, such as state information, quantity of items, the price of items, that the developer never intended for you to see or change.
 
 In the author's experience, it has been very useful to use an intercepting proxy and a spreadsheet for this stage of the testing. The proxy will keep track of every request and response between the tester and the application as they walk through it. Additionally, at this point, testers usually trap every request and response so that they can see exactly every header, parameter, etc. that is being passed to the application and what is being returned. This can be quite tedious at times, especially on large interactive sites (think of a banking application). However, experience will show what to look for and this phase can be significantly reduced.
 
@@ -72,7 +72,7 @@ In this example the tester would note all the parameters as they have before but
 
 Testing for application entry points via a Gray Box methodology would consist of everything already identified above with one addition. In cases where there are external sources from which the application receives data and processes it (such as SNMP traps, syslog messages, SMTP, or SOAP messages from other servers) a meeting with the application developers could identify any functions that would accept or expect user input and how they are formatted. For example, the developer could help in understanding how to formulate a correct SOAP request that the application would accept and where the web service resides (if the web service or any other function hasn't already been identified during the black box testing).
 
-## <a name="tools"></a>Tools
+## Tools
 
 - [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org/)
 - [Burp Suite](https://www.portswigger.net/burp/)

--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -18,7 +18,7 @@ As the tester walks through the application, they should take note of any intere
 
 Below are some points of interests for all requests and responses. Within the requests section, focus on the GET and POST methods, as these appear the majority of the requests. Note that other methods, such as PUT and DELETE, can be used. Often, these more rare requests, if allowed, can expose vulnerabilities. There is a special section in this guide dedicated for testing these HTTP methods.
 
-**Requests:**
+### Requests:
 
 -   Identify where GETs are used and where POSTs are used.
 -   Identify all parameters used in a POST request (these are in the body of the request).
@@ -28,7 +28,7 @@ Below are some points of interests for all requests and responses. Within the re
 -   A special note when it comes to identifying multiple parameters in one string or within a POST request is that some or all of the parameters will be needed to execute the attacks. The tester needs to identify all of the parameters (even if encoded or encrypted) and identify which ones are processed by the application. Later sections of the guide will identify how to test these parameters. At this point, just make sure each one of them is identified.
 -   Also pay attention to any additional or custom type headers not typically seen (such as debug=False).
 
-**Responses:**
+### Responses:
 
 -   Identify where new cookies are set (Set-Cookie header), modified, or added to.
 -   Identify where there are any redirects (3xx HTTP status code), 400 status codes, in particular 403 Forbidden, and 500 internal server errors during normal responses (i.e., unmodified requests).
@@ -36,10 +36,10 @@ Below are some points of interests for all requests and responses. Within the re
 
 ### Black Box Testing
 
-**Testing for application entry points:**
+#### Testing for application entry points:
 The following are two examples on how to check for application entry points.
 
-#### EXAMPLE 1
+##### EXAMPLE 1
 
 This example shows a GET request that would purchase an item from an online shopping application.
 
@@ -51,7 +51,7 @@ This example shows a GET request that would purchase an item from an online shop
 
 Here the tester would note all the parameters of the request such as CUSTOMERID, ITEM, PRICE, IP, and the Cookie (which could just be encoded parameters or used for session state).
 
-#### EXAMPLE 2
+##### EXAMPLE 2
 
 This example shows a POST request that would log you into an application.
 

--- a/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
+++ b/document/4 Web Application Security Testing/4.2 Information Gathering/4.2.6 Identify application entry points (OTG-INFO-006).md
@@ -39,7 +39,7 @@ Below are some points of interests for all requests and responses. Within the re
 #### Testing for application entry points:
 The following are two examples on how to check for application entry points.
 
-##### EXAMPLE 1
+#### EXAMPLE 1
 
 This example shows a GET request that would purchase an item from an online shopping application.
 
@@ -51,7 +51,7 @@ This example shows a GET request that would purchase an item from an online shop
 
 Here the tester would note all the parameters of the request such as CUSTOMERID, ITEM, PRICE, IP, and the Cookie (which could just be encoded parameters or used for session state).
 
-##### EXAMPLE 2
+#### EXAMPLE 2
 
 This example shows a POST request that would log you into an application.
 


### PR DESCRIPTION
This PR covers issue #67.

- [X] This PR handles the issue and requires no additional PRs
  - The most recent comment was to just list the three proxy based debuggers / scanners, which is what is here
- [X] You have validated the need for this change.
  - I can't imagine we want broken links :)

Unfortunately we don't have any standalone browser plugins anymore. I'll gladly add in any browser plugins before the pull request merges, because it's definitely annoying to have to pull in something heavyweight like ZAP or Burp Suite, or do some masterful "curl" work if all you really want is an easy way to put in some funny characters into an HTTP PUT or cookie to see what happens.

**What did this PR accomplish?**

- Removed Tamper and CAT (outdated)
- Added Fiddler reference
- Swapped outdated links out for newer HTTPS links
- Formatted all external reference links as just the name of the resource hyperlinked, following the other pull request on Section 4.10 https://github.com/OWASP/OWASP-Testing-Guide-v5/blob/1a1f127e158e2ab31e7fd59439f7f70fbe1d8e23/document/4%20Web%20Application%20Security%20Testing/4.10%20Testing%20for%20weak%20Cryptography/4.10.4%20Testing%20for%20Weak%20Encryption%20(OTG-CRYPST-004).md (if the link gets destroyed due to the PR merging, I essentially followed section 4.10.4)

Thank you for your contribution!