### PR TITLE
Add length and common passwords to the password policy guidance

### DIFF
--- a/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
+++ b/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
@@ -16,7 +16,7 @@ Determine the resistance of the application against brute force password guessin
 4. How often can a user reuse a password? Does the application maintain a history of the user's previous used 8 passwords?
 5. How different must the next password be from the last password?
 6. Is the user prevented from using his username or other account information (such as first or last name) in the password?
-7. What are the minimum and maximum password lengths that can be set?
+7. What are the minimum and maximum password lengths that can be set, and are they appropriate for the sensitivity of the account and application?
 8. Is it possible set common passwords such as `Password1` or `123456`?
 
 ## References

--- a/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
+++ b/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
@@ -12,7 +12,8 @@ Determine the resistance of the application against brute force password guessin
 
 1. What characters are permitted and forbidden for use within a password? Is the user required to use characters from different character sets such as lower and uppercase letters, digits and special symbols?
 2. How often can a user change their password? How quickly can a user change their password after a previous change? Users may bypass password history requirements by changing their password 5 times in a row so that after the last password change they have configured their initial password again.
-3. When must a user change their password? After 90 days? After account lockout due to excessive log on attempts?
+3. When must a user change their password?
+    * Both [NIST](https://pages.nist.gov/800-63-3/sp800-63b.html#memsecretver) and [NCSC](https://www.ncsc.gov.uk/collection/passwords/updating-your-approach#PasswordGuidance:UpdatingYourApproach-Don'tenforceregularpasswordexpiry) recommend **against** forcing regular password expiry, although it may be required by standards such as PCI DSS.
 4. How often can a user reuse a password? Does the application maintain a history of the user's previous used 8 passwords?
 5. How different must the next password be from the last password?
 6. Is the user prevented from using his username or other account information (such as first or last name) in the password?

--- a/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
+++ b/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The most prevalent and most easily administered authentication mechanism is a static password. The password represents the keys to the kingdom, but is often subverted by users in the name of usability. In each of the recent high profile hacks that have revealed user credentials, it is lamented that most common passwords are still: "123456", "password" and "qwerty".
+The most prevalent and most easily administered authentication mechanism is a static password. The password represents the keys to the kingdom, but is often subverted by users in the name of usability. In each of the recent high profile hacks that have revealed user credentials, it is lamented that most common passwords are still: `123456`, `password` and `qwerty`.
 
 ## Test Objectives
 
@@ -17,7 +17,7 @@ Determine the resistance of the application against brute force password guessin
 5. How different must the next password be from the last password?
 6. Is the user prevented from using his username or other account information (such as first or last name) in the password?
 7. What are the minimum and maximum password lengths that can be set?
-8. Is it possible set common passwords such as "Password1" or "123456"?
+8. Is it possible set common passwords such as `Password1` or `123456`?
 
 ## References
 

--- a/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
+++ b/document/4_Web_Application_Security_Testing/4.5_Authentication_Testing/4.5.7_Testing_for_Weak_Password_Policy_OTG-AUTHN-007.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The most prevalent and most easily administered authentication mechanism is a static password. The password represents the keys to the kingdom, but is often subverted by users in the name of usability. In each of the recent high profile hacks that have revealed user credentials, it is lamented that most common passwords are still: 123456, password and qwerty.
+The most prevalent and most easily administered authentication mechanism is a static password. The password represents the keys to the kingdom, but is often subverted by users in the name of usability. In each of the recent high profile hacks that have revealed user credentials, it is lamented that most common passwords are still: "123456", "password" and "qwerty".
 
 ## Test Objectives
 
@@ -16,6 +16,8 @@ Determine the resistance of the application against brute force password guessin
 4. How often can a user reuse a password? Does the application maintain a history of the user's previous used 8 passwords?
 5. How different must the next password be from the last password?
 6. Is the user prevented from using his username or other account information (such as first or last name) in the password?
+7. What are the minimum and maximum password lengths that can be set?
+8. Is it possible set common passwords such as "Password1" or "123456"?
 
 ## References
 
@@ -23,4 +25,4 @@ Determine the resistance of the application against brute force password guessin
 
 ## Remediation
 
-To mitigate the risk of easily guessed passwords facilitating unauthorized access there are two solutions: introduce additional authentication controls (i.e. two-factor authentication) or introduce a strong password policy. The simplest and cheapest of these is the introduction of a strong password policy that ensures password length, complexity, reuse and aging.
+To mitigate the risk of easily guessed passwords facilitating unauthorized access there are two solutions: introduce additional authentication controls (i.e. two-factor authentication) or introduce a strong password policy. The simplest and cheapest of these is the introduction of a strong password policy that ensures password length, complexity, reuse and aging; although ideally both of them should be implemented.


### PR DESCRIPTION
The current password policy testing guide doesn't mention two key areas:

* Password length (both minimum and maximum)
* Blocking common passwords such as "Password1"

Also updated the remediation guidance, because at the moment it presents a strong password policy and MFA as an either/or situation, whereas really you should be implementing both.